### PR TITLE
Fix issue when csv or mp4 could be picked from first element of listdir

### DIFF
--- a/local_extract/src/sm_utils.py
+++ b/local_extract/src/sm_utils.py
@@ -39,9 +39,8 @@ def extract_frame_data(target_dir, video_path):
         ), "Frame number in video %d and timestamp files %d did not match" % (
             len_files, len(filename_timestamps))
 
-        _, extension = os.path.splitext(os.listdir(target_dir)[0])
         for i, timestamp in enumerate(filename_timestamps):
             os.rename(
                 os.path.join(target_dir, "frame-%d.png" % (i + 1)),
-                os.path.join(target_dir, timestamp[0] + extension)
+                os.path.join(target_dir, timestamp[0] + ".png")
             )


### PR DESCRIPTION
`listdir` doesn't provide any specific order of elements, thus csv or mp4 could be picked and frames have wrong extension. Maybe more proper fix is required.